### PR TITLE
feat: usere following implemented

### DIFF
--- a/app/(browse)/_components/sidebar/followed.tsx
+++ b/app/(browse)/_components/sidebar/followed.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { Follow, User } from "@prisma/client";
+import { UserItem, UserItemSkeleton } from "./user-item";
+import { useSideBar } from "@/store/use-sidebar";
+
+interface FollowedProps {
+    data: (Follow & {following:User}[]),
+}
+
+const Followed = ({
+    data
+}: FollowedProps) => {
+    const { collapsed } = useSideBar((state) => state);
+    if(!data.length) {
+        return null
+    };
+
+    return (  
+        <div>
+            {!collapsed && (
+            <div className="pl-6 mb-4">
+                <p className="text-sm text-muted-foreground">
+                    Followed Users
+                </p>
+            </div>
+            )}
+            <ul className="space-y-2 px-2">
+                {data.map((user) => (
+                    <UserItem 
+                        key={user.following.id}
+                        username={user.following.username}
+                        imageUrl={user.following.imageUrl}
+                        isStreaming={true}/>
+                ))}
+            </ul>
+        </div>
+    );
+}
+ 
+export default Followed;
+
+export const FollowedSkeleton = () => {
+    return (
+        <ul className="px-2 pt-2 lg:pt-0">
+            {[...Array(3)].map((_, i) =>(
+                <UserItemSkeleton key={i} />
+            ))}
+        </ul>
+    )
+}

--- a/app/(browse)/_components/sidebar/index.tsx
+++ b/app/(browse)/_components/sidebar/index.tsx
@@ -2,14 +2,18 @@ import { getRecomended } from "@/lib/recomended-service";
 import Recommended, { RecommendedSkeleton } from "./recomended";
 import Toggle, { ToggleSkeleton } from "./toggle";
 import Wrapper from "./wrapper";
+import { getFollowedUsers } from "@/lib/follow-service";
+import Followed, { FollowedSkeleton } from "./followed";
 
 const Sidebar = async () => {
     const recomendedUsers = await getRecomended();
+    const followedUsers = await getFollowedUsers();
     
     return ( 
     <Wrapper>
         <Toggle/>
         <div className="space-y-4 pt-4 lg:pt-0">
+            <Followed data={followedUsers} />
             <Recommended data={recomendedUsers}/>
         </div>
     </Wrapper>
@@ -22,6 +26,7 @@ export const SidebarSkeleton = () => {
     return (
         <aside className="fixed left-0 flex flex-col w-[70px] lg:w-60 h-full bg-background border-r border-[#2D2E35] z-50">
             <ToggleSkeleton />
+            <FollowedSkeleton />
             <RecommendedSkeleton />
         </aside>
     )

--- a/app/(browse)/_components/sidebar/wrapper.tsx
+++ b/app/(browse)/_components/sidebar/wrapper.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 import { ToggleSkeleton } from "./toggle";
 import { useIsClient } from "usehooks-ts";
 import { RecommendedSkeleton } from "./recomended";
+import { FollowedSkeleton } from "./followed";
 
 interface WrapperProps {
     children: React.ReactNode
@@ -22,6 +23,7 @@ const Wrapper = ({
     if(!isClient) {
         <aside className="fixed left-0 flex flex-col w-[70px] lg:w-60 h-full bg-background border-r border-[#2D2E35] z-50">
             <ToggleSkeleton/>
+            <FollowedSkeleton />
             <RecommendedSkeleton/>
         </aside>
     }

--- a/lib/follow-service.ts
+++ b/lib/follow-service.ts
@@ -84,3 +84,21 @@ export const unfollowUser = async (id: string) => {
 
     return follow;
 }
+
+export const getFollowedUsers = async () => {
+    try {
+        const self = await getSelf();
+        
+        const followedUsers =  db.follow.findMany({
+            where: {
+                followerId: self.id,
+            },
+            include: {
+                following: true,
+            }
+        })
+        return followedUsers;
+    } catch {
+        return [];
+    }
+}

--- a/lib/recomended-service.ts
+++ b/lib/recomended-service.ts
@@ -17,9 +17,22 @@ export const getRecomended = async () => {
     if(userId) {
         userArray = await db.user.findMany({
             where: {
-                NOT:  {
-                    id: userId
-                }
+                AND: [
+                    {
+                        NOT:  {
+                            id: userId
+                        },
+                    },
+                    {
+                        NOT:  {
+                            follow: {
+                                some: {
+                                    followerId : userId
+                                }
+                            }
+                        }
+                    }
+                ]
             },
             orderBy: {
                 createdAt: "desc"


### PR DESCRIPTION
- there is a different component for the users which the logged in user follows at the sidebar If I am a logged in user and i start following an account then I am only going to see that user at the "Followed Users" section so there is no redundancy when we display the accounts